### PR TITLE
dev: Update vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
   "editor.fontFamily": "'Google Sans Code', JetBrains Mono, Consolas, monospace",
   "editor.fontLigatures": true,
   "editor.fontSize": 17,
-  "editor.lineHeight": 1.5,
+  "editor.lineHeight": 1.618,
   "editor.cursorSmoothCaretAnimation": "on",
   //#endregion: font
 
@@ -13,36 +13,36 @@
 
   //#region: MARK: formating
   "editor.tabSize": 2,
+  "editor.formatOnSave": true,
+  "editor.formatOnPaste": true,
   "editor.insertSpaces": true,
   "editor.detectIndentation": true,
 
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "[html]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
   },
   "[javascript]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
   },
   "[typescript]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
   },
   //#endregion: formating
 
   //#region: MARK: snippets
-  "editor.formatOnSave": true,
-  "editor.formatOnPaste": true,
-  // Forces snippets to show up at the top of the autocomplete box
   "editor.snippetSuggestions": "inline",
-
-  // Enables snippet autocompletion inside text, code, strings, and markdown
   "editor.quickSuggestions": {
     "other": "on",
     "comments": "on",
-    "strings": "on"
+    "strings": "on",
   },
   //#endregion: snippets
 
+  //#region: MARK: js/ts
+  "js/ts.updateImportsOnFileMove.enabled": "always",
+  //#endregion: js/ts
+
   "git.enableSmartCommit": true,
   "explorer.confirmDragAndDrop": false,
-  "js/ts.updateImportsOnFileMove.enabled": "always"
 }


### PR DESCRIPTION
## Objective

- Updates formatting and imports settings for vscode.
- Changes line-height to `1.618`, from **zed**'s comfortable line-height value

---

### Testing

- Tested the settings in vscode

### Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

### Release Notes:

- N/A
