### PR TITLE
dev(lint): Fix TS `no-undef` error

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,9 +6,8 @@ export default tseslint.config(
   js.configs.recommended,
   ...tseslint.configs.recommended,
 
-  // Custom rules & environment flags
   {
-    files: ["**/*.js", "**/*.ts"],
+    files: ["**/*.ts", "**/*.js"],
     languageOptions: {
       globals: {
         ...globals.browser,
@@ -17,6 +16,11 @@ export default tseslint.config(
     },
     rules: {
       "no-redeclare": "error",
+    },
+  },
+  {
+    files: ["**/*.js"],
+    rules: {
       "no-undef": "error",
     },
   },


### PR DESCRIPTION
## Objective

`typescript-eslint` shows error for browser variables, because `eslint.config.js` has `"no-undef": "error"` rule.

## Solution

- Remove the rule from `eslint.config.js`.

---

### Testing

- Eslint doesn't show errors now.

### Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

### Release Notes:

- N/A